### PR TITLE
Trim extra reddit post info

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -43,8 +43,11 @@ def get_reddit_user_posts(username):
 
 
 def get_reddit_preview(text):
-    return BeautifulSoup(text, "html.parser").text[:266]  # 266 is Max. length of dota blog summaries
-
+    preview = BeautifulSoup(text, "html.parser")
+     # filter out extra reddit info before trimming
+    formattedPreview = preview[:preview.find("submitted by    /u/")]
+    formattedPreview = formattedPreview[:266] # 266 is Max. length of dota blog summaries
+    return formattedPreview
 
 def get_relevant_sirbelvedere_posts():
     posts = get_reddit_user_posts("SirBelvedere")


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **development branch** (left side). Also you should start *your branch* off *our development*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description
Fix for #37 - Improve Reddit Post Dsiplay.

The get_reddit_preview function now filters out the extra 'Submitted by...' info returned by the reddit RSS feed to prevent it showing on the bots message preview

💔Thank you!
